### PR TITLE
resend webmention to a link if the link is removed

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -47,6 +47,7 @@ func TestFindWork(t *testing.T) {
 		"https://my-awesome.site/testdata/page/",
 		"http://some.site/post/title",
 		"https://my-awesome.site/other/",
+		"http://example.site/post",
 	}
 
 	if !stringSlicesEqual(got, want) {
@@ -103,6 +104,7 @@ func TestCompareDirs(t *testing.T) {
 		"posts/1/index.html",
 		"posts/2/index.html",
 		"posts/3/index.html",
+		"posts/4/index.html",
 	}
 
 	if !stringSlicesEqual(got, want) {

--- a/testdata/prod/posts/4/index.html
+++ b/testdata/prod/posts/4/index.html
@@ -1,0 +1,1 @@
+<html><span class=h-entry>Some text, and there's a <a href="http://example.site/post">link</a>, too!</span></html>

--- a/testdata/prod/posts/index.html
+++ b/testdata/prod/posts/index.html
@@ -1,0 +1,1 @@
+<html><span class=h-entry>Some text, and there's a <a href="http://example.site/somepost">link</a>, too!</span></html>

--- a/testdata/staging/posts/4/index.html
+++ b/testdata/staging/posts/4/index.html
@@ -1,0 +1,1 @@
+<html><span class=h-entry>something</span></html>


### PR DESCRIPTION
Per spec:

> If the source URL was updated, the sender SHOULD re-send any previously sent Webmentions, (including re-sending a Webmention to a URL that may have been removed from the document), and SHOULD send Webmentions for any new links that appear at the URL.

fixes #16 